### PR TITLE
Fix finding rev in hg repo with no outgoing commits

### DIFF
--- a/pernosco-submit
+++ b/pernosco-submit
@@ -255,7 +255,7 @@ def hg_find_rev(repo_path, remotes):
     best_sha = None
     best_remote = None
     for r in remotes:
-        output = subprocess.check_output(['hg', 'log', '-T', '{rev} {node}', '-r', "ancestor(parents(outgoing('%s') & ancestors(.)))"%r],
+        output = subprocess.check_output(['hg', 'log', '-T', '{rev} {node}', '-r', "ancestor((parents(outgoing('%s') & ancestors(.))) | .)"%r],
                                          cwd=repo_path).decode('utf-8')
         [rev_num, sha] = output.split()[:2]
         rev_num = int(rev_num)


### PR DESCRIPTION
The script seemed to be all right at finding a published ancestor if the
current workdir was an outgoing commit. However, in case the checked-out
commit was already published, the `hg log` command came up empty.
`output.split()[:2]` would then throw an error because `output` was the
empty string.

This patch alleviates that by including the checked-out commit in the
list of outgoing commits to find a common ancestor for.