### PR TITLE
When using aws-cli v2, use the legacy encoding behavior for lambda invokes

### DIFF
--- a/pernosco-submit
+++ b/pernosco-submit
@@ -39,6 +39,8 @@ PublicKey = NewType('PublicKey', str)
 Signature = NewType('Signature', str)
 Nonce = NewType('Nonce', str)
 
+isAwsCliV2 = base.check_output(['aws', '--version']).decode('utf-8').startswith("aws-cli/2.")
+
 class CryptoData(TypedDict):
     public_key: PublicKey
     signature: Signature
@@ -368,6 +370,8 @@ def upload_file(nonce: Nonce, signature: Signature, aws_access_key_id: AwsAccess
         checker_args.extend([os.environ['PERNOSCO_CREDENTIAL_CHECKER']])
     else:
         checker_args.extend(["PROD"])
+    if isAwsCliV2:
+        checker_args.extend(["--cli-binary-format", "raw-in-base64-out"])
     checker_args.extend(["--payload", "\"publickey=%s,user=%s,group=%s\""%(strip_wrapper(public_key), pernosco_user, pernosco_group), "/dev/null"])
 
     aws_cmd = ["aws", "s3", "cp", "--metadata", metadata, "--endpoint-url", "https://s3-accelerate.amazonaws.com", payload_file_name, s3_url]


### PR DESCRIPTION
Fixes #16.